### PR TITLE
⚡ perf(waka-readme): 重い設定 OFF + timeout 10 min で 33 分ハング対策

### DIFF
--- a/.github/workflows/waka-readme.yml
+++ b/.github/workflows/waka-readme.yml
@@ -12,22 +12,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: anmol098/waka-readme-stats@master
+        timeout-minutes: 10
         with:
           WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          # 重い処理 (全リポ走査が必要) は OFF にして 5 分以内に完走させる
+          SHOW_LOC_CHART: "False"
+          SHOW_LINES_OF_CODE: "False"
+          SHOW_LANGUAGE_PER_REPO: "False"
+          SHOW_DAYS_OF_WEEK: "False"
+          SHOW_COMMIT: "False"
+          SHOW_PROFILE_VIEWS: "False"
+          # 軽い処理 (WakaTime API のみで完結) は ON
           SHOW_TIMEZONE: "True"
           SHOW_PROJECTS: "True"
           SHOW_EDITORS: "True"
           SHOW_OS: "True"
           SHOW_LANGUAGE: "True"
-          SHOW_LANGUAGE_PER_REPO: "False"
-          SHOW_LOC_CHART: "True"
-          SHOW_PROFILE_VIEWS: "False"
-          SHOW_LINES_OF_CODE: "False"
           SHOW_TOTAL_CODE_TIME: "True"
           SHOW_SHORT_INFO: "True"
-          SHOW_COMMIT: "True"
-          SHOW_DAYS_OF_WEEK: "True"
           SHOW_UPDATED_DATE: "True"
           COMMIT_BY_ME: "False"
           COMMIT_MESSAGE: ":bar_chart: Update WakaTime stats"


### PR DESCRIPTION
## 概要

WakaTime workflow が 33 分経過で `in_progress` のまま完了せず cancelled になった (run 25093394932) ため、重い設定を OFF にして 5 分以内に完走させる。

## 原因

`SHOW_LOC_CHART` / `SHOW_LINES_OF_CODE` / `SHOW_DAYS_OF_WEEK` / `SHOW_COMMIT` は全リポを git clone して全コミット走査する重い処理。cardene777 のリポ数 70+ では数十分必要。

## 修正

1. `timeout-minutes: 10` を追加で安全網
2. 重い設定 OFF
   - `SHOW_LOC_CHART`: True → False
   - `SHOW_DAYS_OF_WEEK`: True → False
   - `SHOW_COMMIT`: True → False
3. 軽い設定は ON 維持
   - TIMEZONE / PROJECTS / EDITORS / OS / LANGUAGE / TOTAL_CODE_TIME / SHORT_INFO / UPDATED_DATE

## 期待

5 分以内で完走し WakaTime stats が README に挿入される。

## Test plan

- [ ] PR マージ後、`gh workflow run waka-readme.yml` で再実行
- [ ] 5 分以内に completed になること
- [ ] README の `<!--START_SECTION:waka-->` 〜 `<!--END_SECTION:waka-->` 間に統計が挿入されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 更新内容

* **その他（Chores）**
  * 自動化ワークフロー実行時間に10分のタイムアウト制限を追加
  * プロフィール統計の生成から複数セクション（行数チャート、リポジトリ別分析、曜日統計など）を無効化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->