### PR TITLE
🎨 profile: trophy を 3x6 全表示に拡張

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ blog     → <a href="https://chaldene.net">chaldene.net</a>
 
 <br />
 
-<img src="https://github-profile-trophy.vercel.app/?username=cardene777&theme=onedark&no-frame=true&no-bg=true&row=2&column=4&margin-w=15&margin-h=15&rank=SECRET,SSS,SS,S,AAA,AA,A,B" alt="trophy" />
+<img src="https://github-profile-trophy.vercel.app/?username=cardene777&theme=onedark&no-frame=true&no-bg=true&row=3&column=6&margin-w=10&margin-h=10" alt="trophy" />
 
 </div>
 


### PR DESCRIPTION
## 概要

ユーザー要望「全 trophy 表示 (A 案)」への対応。trophy グリッドを 8 個 → 18 個に拡張し rank フィルタも撤廃。

## 変更

| パラメータ | 旧 | 新 |
|---|---|---|
| `row` | 2 | 3 |
| `column` | 4 | 6 |
| `rank` | `SECRET,SSS,SS,S,AAA,AA,A,B` | (撤廃) |
| `margin-w` | 15 | 10 |
| `margin-h` | 15 | 10 |

## 期待

- 取得済み trophy 全種類 (Stars / Followers / Commits / PullRequest / Reviews / Issues / Repositories / Forks / Experience / HotStreak / MultiLanguage / LongTimeUser / etc 最大 18 個) が 1 画面で並ぶ
- rank 制限なしで低 rank も含めて見せる
- 余白圧縮で個数増えても 1 画面に収まる

## Test plan

- [ ] PR マージ後 README で trophy セクションを確認
- [ ] 18 個まで表示されること
- [ ] 緑黒テーマと色味のバランスを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * アワード表示のレイアウトを最適化しました。グリッド配置と余白を調整し、より良い表示形式を実現しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->