### PR TITLE
🔥 profile: joke セクション削除 (GitHub README で動かない)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,20 +71,6 @@ blog     → <a href="https://chaldene.net">chaldene.net</a>
 
 <br />
 
-<!-- ═══════════ 2. JOKE (旧 ls projects 位置) ═══════════ -->
-
-<div align="center">
-
-<img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=700&size=18&duration=1&pause=99999&color=4ADE80&width=720&height=28&lines=%24+joke+--random" alt="joke" />
-
-<br />
-
-<img src="https://readme-jokes.vercel.app/api?theme=algolia&hideBorder=true" alt="joke" />
-
-</div>
-
-<br />
-
 <!-- ═══════════ 3. STATS ═══════════ -->
 
 <div align="center">


### PR DESCRIPTION
## 概要

ユーザー指摘「joke が収まりきってない？エラーになってる？」への対応。

## 原因

`readme-jokes.vercel.app` の SVG は `<script>` でテキストを動的描画する設計。GitHub README は sanitize で `<script>` を全削除するため、テキストが描画されず空枠 / エラー画像っぽい見た目になる。

## 対処

- README L74-86 の `JOKE` セクションを完全削除
- 隣接 `<br />` も整理

## 代替検討結果

- `random-jokes-api.vercel.app`: 404 (停止)
- 他 joke API も `<script>` 依存 / Heroku 廃止で軒並み NG
- 静的ジョーク手書きはユーザーアイデンティティと無関係でノイズ

## Test plan

- [ ] PR マージ後、README から JOKE セクションが消えていること
- [ ] STATS / ACTIVITY 等の他セクションが詰まらず正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * README のジョークセクションを削除しました。これにより、ドキュメントのレイアウトが簡潔化され、主要な統計情報セクションへスムーズにアクセスできるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->