### PR TITLE
:memo: Fix activity graph period to 31 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ blog     → <a href="https://chaldene.net">chaldene.net</a>
 
 <div align="center">
 
-<img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=700&size=18&duration=1&pause=99999&color=4ADE80&width=720&height=28&lines=%24+git+log+--graph+%7C+tail+-365" alt="git log" />
+<img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=700&size=18&duration=1&pause=99999&color=4ADE80&width=720&height=28&lines=%24+git+log+--graph+%7C+tail+-31" alt="git log" />
 
 <br />
 
-<img src="https://github-readme-activity-graph.vercel.app/graph?username=cardene777&bg_color=0d1117&color=4ade80&line=4ade80&point=fbbf24&area=true&area_color=4ade80&radius=10&custom_title=Contributions+in+the+Last+Year&title_color=4ade80" alt="activity" />
+<img src="https://github-readme-activity-graph.vercel.app/graph?username=cardene777&bg_color=0d1117&color=4ade80&line=4ade80&point=fbbf24&area=true&area_color=4ade80&radius=10&custom_title=Activity+in+the+Last+31+Days&title_color=4ade80" alt="activity" />
 
 </div>
 


### PR DESCRIPTION
## Summary

- `github-readme-activity-graph` サービスの `days` パラメータ上限が 31 日のため、タイトル文言と見出し（`tail -365`）を実態に合わせて修正
- 1 年分の表示は直下の 3D contrib セクション（`profile-3d-contrib/profile-night-green.svg`）が既に担っているため折れ線は 31 日のスパークラインに役割を絞る

## Changes

| 項目 | Before | After |
|---|---|---|
| 見出し | `$ git log --graph \| tail -365` | `$ git log --graph \| tail -31` |
| custom_title | `Contributions in the Last Year` | `Activity in the Last 31 Days` |

## Why

`custom_title=Last+Year` と書いていても実データは 31 日にクランプされるため、タイトルと中身が乖離していた。サービス仕様 ([ashutosh00710/github-readme-activity-graph](https://github.com/Ashutosh00710/github-readme-activity-graph)) で `days` の最大値は 31。

## Test plan

- [x] 修正後の URL で SVG が 200 で返ることを確認
- [x] git diff で意図通り 2 行のみの修正であることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメンテーション**
  * アクティビティセクションの表示期間を更新しました。貢献グラフが「過去1年間の貢献」から「過去31日間のアクティビティ」に変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->